### PR TITLE
Fix SkySand yellow energy nook logic error

### DIFF
--- a/worlds/aus/Rules.py
+++ b/worlds/aus/Rules.py
@@ -280,10 +280,10 @@ class AUSRules:
             L_SKYSAND_FLOWER: true,
             L_SKYSAND_BOTTOMSAVE: lambda state: self.has_ice(state) and (
                         self.has_red_energy(state) or self.jump_height_min(state, 8)) and self.can_stick(state),
-            L_SKYSAND_POSTBOSS: lambda state: self.has_yellow_energy(state) and self.double_jump_min(state, 3),
+            L_SKYSAND_POSTBOSS: true,
             L_SKYSAND_BOSS: true,
             L_SKYSAND_UPPERDOOR: true,
-            L_SKYSAND_YELLOW: true,
+            L_SKYSAND_YELLOW: lambda state: self.has_yellow_energy(state) and self.double_jump_min(state, 3),
             L_SKYSAND_LOWERDOOR: true,
             L_SKYSAND_CHEST: true,
         }


### PR DESCRIPTION
## What is this fixing or adding?
Logic error where the player is expected to check SkySand yellow energy nook without yellow energy.

## How was this tested?
Plando Dive Bomb into the yellow energy nook and Yellow Energy into BlackCastle. Before the fix, the generation placed those two items into their plando'd locations; after the fix, the generation detected an impossible playthrough and altered their placement.
